### PR TITLE
fix: enhance inactive tab styling with border

### DIFF
--- a/packages/react/src/components/Tabs/index.tsx
+++ b/packages/react/src/components/Tabs/index.tsx
@@ -40,7 +40,7 @@ const Tabs: React.FC<TabsProps> = ({ tabs, grow = true, value, onChange }) => {
   });
 
   const inactiveTabClasses = clsx({
-    ['text-neutral-600']: true,
+    ['text-neutral-600 border-b-2 border-black']: true,
   });
 
   const handleTabClick = (tabId: string) => {


### PR DESCRIPTION
Inserido um border inferior no Component TAB quando INATIVO